### PR TITLE
12h mode clock always showing AM

### DIFF
--- a/js/clock.js
+++ b/js/clock.js
@@ -28,9 +28,9 @@ class Clock {
 		}
 		
 		// 12-hour mode
+		midDay = (hour >= 12) ? 'PM' : 'AM';
 		hour = (hour === 0) ? 12 : ((hour > 12) ? (hour - 12) : hour);
 		hour = this._appendZero(hour);
-		midDay = (hour >= 12) ? 'PM' : 'AM';
 		this._clock.innerText = `${hour}:${min} ${midDay}`;
 	}
 


### PR DESCRIPTION
Clock is always showing AM as the midDay variable is being calculated after converting hours to 12h mode.

Calculating that variable before converting hours to 12h mode fixes the issue