### PR TITLE
Changing font families in configuration

### DIFF
--- a/css/central-body.css
+++ b/css/central-body.css
@@ -16,7 +16,6 @@
 }
 
 #clock {
-	font-family: 'Inter', 'SF Pro Text', 'Roboto', sans-serif;
 	font-weight: bold;
 	font-size: 88pt;
 	color: var(--clock-color);
@@ -33,7 +32,6 @@
 }
 
 #search-box {
-	font-family: 'Inter', 'SF Pro Text', 'Roboto', sans-serif;
 	background: var(--base-bg);
 	color: var(--font-color);
 	font-size: 14pt;

--- a/css/global.css
+++ b/css/global.css
@@ -46,7 +46,6 @@ body {
 	padding: 0;
 	height: 100%;
 	position: fixed;
-	font-family: 'Inter', 'SF Pro Text', 'Roboto', sans-serif;
 }
 
 body {

--- a/css/suggestions.css
+++ b/css/suggestions.css
@@ -34,7 +34,6 @@ li.suggestion {
 li button.suggestion-button {
 	background: transparent;
 	color: var(--font-color);
-	font-family: 'Inter', 'SF Pro Text', 'Roboto', sans-serif;
 	font-size: 12pt;
 	border: none;
 	width: auto;

--- a/css/web-menu.css
+++ b/css/web-menu.css
@@ -53,7 +53,6 @@
 #web-menu-searchbox {
 	background: var(--base-secondary-bg);
 	color: var(--font-color);
-	font-family: 'Inter', 'SF Pro Text', 'Roboto', sans-serif;
 	font-size: 12pt;
 	font-weight: 700;
 	text-align: center;
@@ -65,7 +64,6 @@
 }
 
 #web-menu-searchbox::placeholder {
-	font-family: 'Inter', 'SF Pro Text', 'Roboto', sans-serif;
 	font-size: 11pt;
 	font-weight: 700;
 }
@@ -146,7 +144,6 @@
 .web-item-name {
 	text-align: center;
 	font-size: 11pt;
-	font-family: 'Inter', 'SF Pro Text', 'Roboto', sans-serif;
 	font-weight: 400;
 	word-wrap: break-word;
 	color: var(--font-color);
@@ -176,7 +173,6 @@
 }
 
 .category-name {
-	font-family: 'Inter', 'SF Pro Text', 'Roboto', sans-serif;
 	font-weight: 700;
 	color: var(--font-color);
 	margin: 0 5px;

--- a/js/config.js
+++ b/js/config.js
@@ -1,5 +1,5 @@
 class Config {
-	constructor() {}
+	constructor() { }
 
 	getThemeMode() {
 		const themeModes = {
@@ -17,9 +17,19 @@ class Config {
 				lightHour: '7',
 				darkHour: '18'
 			}
-		}
+		};
 
 		return themeModes;
+	}
+
+	getFontFamily() {
+		const fontFamilies = {
+			'monospace': 'Fira Code Retina, Hack, Ubuntu Mono, Monaco, Lucida Console, monospace',
+			'sans-serif': 'Inter, SF Pro Text, Roboto, Open Sans, sans-serif',
+			'serif': 'serif'
+		};
+
+		return fontFamilies;
 	}
 
 	getQuickSearchData() {
@@ -34,7 +44,7 @@ class Config {
 				urlPrefix: 'https://unsplash.com/s/photos/'
 			},
 			'a/': {
-				urlPrefix: 'https://amazon.com/s?k='	
+				urlPrefix: 'https://amazon.com/s?k='
 			},
 			'e/': {
 				urlPrefix: 'https://ebay.com/sch/?_nkw='
@@ -43,10 +53,10 @@ class Config {
 				urlPrefix: 'https://youtube.com/results?search_query='
 			},
 			'n/': {
-				urlPrefix: 'https://nhentai.net/g/'	
+				urlPrefix: 'https://nhentai.net/g/'
 			},
 			'g/': {
-				urlPrefix: 'https://github.com/search?q='	
+				urlPrefix: 'https://github.com/search?q='
 			}
 		};
 

--- a/js/script.js
+++ b/js/script.js
@@ -37,3 +37,7 @@ const themeSwitcher = new ThemeSwitcher();
 // Instantiate key events
 const documentKeyEvents = new DocumentKeyEvents();
 
+// Set Font Family
+document.querySelector('body').style.setProperty(
+  'font-family', config.getFontFamily()['sans-serif']
+);

--- a/js/search-query-send.js
+++ b/js/search-query-send.js
@@ -46,5 +46,5 @@ class SearchQuerySend {
 		}
 		
 		this._openURL(searchEngineSwitcher.getSearchEngineURLPrefix() + searchQuery);
-	};
+	}
 }

--- a/js/suggestions.js
+++ b/js/suggestions.js
@@ -52,7 +52,7 @@ class AutoSuggestion {
 			if (this._searchBoxValue) {
 				this._searchBox.value = this._searchBoxValue
 				this._searchBoxValue = null;
-			};
+			}
 			this._searchBox.focus();
 		}
 

--- a/js/web-menu.js
+++ b/js/web-menu.js
@@ -102,7 +102,7 @@ class WebMenu {
 	// Create LI
 	_createItemCategoryLI(url, siteID, icon, site, categoryID, categoryUL) {
 		const li = document.createElement('li');
-		li.className = `web-menu-list-item web-menu-categorized`;
+		li.className = 'web-menu-list-item web-menu-categorized';
 		li.id = `web-menu-category-${categoryID}`;
 
 		// Generate web item/li child
@@ -130,16 +130,16 @@ class WebMenu {
 
 	_createCatregories(category, categoryID) {
 		const categoryBodyDivID = document.createElement('li');
-		categoryBodyDivID.className = `category-body`;
+		categoryBodyDivID.className = 'category-body';
 		categoryBodyDivID.id = `category-body-${categoryID}`;
 
 		const categoryNameH3ID = document.createElement('h3');
-		categoryNameH3ID.className = `category-name`;
+		categoryNameH3ID.className = 'category-name';
 		categoryNameH3ID.id = `category-name-${categoryID}`;
 		categoryNameH3ID.innerText = `${this._capitalizeString(category)}`;
 
 		const categoryUL = document.createElement('ul');
-		categoryUL.className = `category-list`;
+		categoryUL.className = 'category-list';
 		categoryUL.id = `category-list-${categoryID}`;
 
 		categoryBodyDivID.appendChild(categoryNameH3ID);
@@ -181,7 +181,7 @@ class WebMenu {
 			const categoryID = this._whiteSpaceToDash(category);
 
 			const li = document.createElement('li');
-			li.className = `web-menu-list-item web-menu-categorized`;
+			li.className = 'web-menu-list-item web-menu-categorized';
 			li.id = `web-menu-category-${categoryID}`;
 
 			// Generate web item/li child


### PR DESCRIPTION
Implemented font family switching via entry-point `script.js` which gets the appropriate font family from `config.js` and changes the DOM programmatically. It is `sans-serif` by default but changing the value to `monospace` changes the DOM font family to a set of monospaced fonts.

Removed redundant code in stylesheets. Also fixed inconsistencies with quotes, enforcing single quotes across JavaScript files.

![mono1](https://user-images.githubusercontent.com/11232940/94983181-d646e580-055d-11eb-982a-dab41c035111.jpg)

![mono2](https://user-images.githubusercontent.com/11232940/94983179-d515b880-055d-11eb-9ba1-b7e41285a0da.jpg)

_This PR was made as part of Hacktoberfest 2020. Add `hacktoberfest-accepted` label if accepted._