### PR TITLE
small change in media query

### DIFF
--- a/css/web-menu.css
+++ b/css/web-menu.css
@@ -264,6 +264,7 @@
 
 	.web-item {
 		width: auto;
+		margin: 5px 1.2rem;
 	}
 
 	.web-item:hover {


### PR DESCRIPTION
On devices having very less width (like iphone SE) , the panel starts to overlay the web item cards in normal mode view.
Added a margin property in media query for max-width : 470px .

Before: 
![Screenshot (99)](https://user-images.githubusercontent.com/38114116/94984684-32b10180-056c-11eb-8804-c5a9da76f39f.png)


After : 
![Screenshot (97)](https://user-images.githubusercontent.com/38114116/94984660-f54c7400-056b-11eb-97cb-6145700148c2.png)

